### PR TITLE
Test that child's SIGALRM handler is reset

### DIFF
--- a/tests/src/ForkerTest.php
+++ b/tests/src/ForkerTest.php
@@ -202,4 +202,20 @@ class ForkerTest extends PHPUnit_Framework_TestCase
             $forker->run()
         );
     }
+
+    public function testChildDoesNotHaveAlarmSignalHandlerSet()
+    {
+        $forker = new Forker();
+
+        $process_title_check = function () {
+            posix_kill(getmypid(), SIGALRM);
+            pcntl_signal_dispatch();
+
+            return 0;
+        };
+
+        $forker->add($process_title_check, ['timeout' => 1]);
+
+        $this->assertEquals([-SIGALRM], $forker->run());
+    }
 }


### PR DESCRIPTION
The signal handler is inherited from the parent process, but the signal
handler is not relevant to the child process. Make sure the child
process is assigned the default signal handler on initiation.

Issue #2